### PR TITLE
Update Jwt.cs

### DIFF
--- a/EnablerEchoBot-v4/WebAppBot-v4/c# example/ContextService examples/Jwt.cs
+++ b/EnablerEchoBot-v4/WebAppBot-v4/c# example/ContextService examples/Jwt.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Jose;
 using System.Security.Cryptography.X509Certificates;
+using EscalationBot.Context;
 
 
 /// <summary>


### PR DESCRIPTION
Without this build v4 bot results in the following error. 
\Jwt.cs(27,46): error CS0246: The type or namespace name 'NewtonsoftMapper' could not be found (are you missing a using directive or an assembly reference?) 
\Jwt.cs(60,50): error CS0246: The type or namespace name 'NewtonsoftMapper' could not be found (are you missing a using directive or an assembly reference?) [